### PR TITLE
Url sans html

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 9.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- URL : Suppression du ".html" en fin d'adresse
+- URL : Utilisation des liens en ".html" sans rejet 404
+- URL : N'affiche plus "index" par défaut sur l'accueil
 
 
 9.5.2 (2022-12-27)

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -189,7 +189,9 @@ def index(page=None):
     if not page:
         page = "index"
         redirect = True
-
+    if page[-5:] == ".html":
+        page = page[:-5]
+        redirect = True
     page = "/" + page
     if redirect:
         return flask.redirect(page, 301)

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -188,7 +188,6 @@ def index(page=None):
     redirect = False
     if not page:
         page = "index"
-        redirect = True
     if page[-5:] == ".html":
         page = page[:-5]
         redirect = True

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -196,7 +196,7 @@ def index(page=None):
         return flask.redirect(page, 301)
 
     context = copy.copy(BASE_CONTEXT)
-    return flask.render_template(page + ".html", **context)
+    return render_template(page + ".html", **context)
 
 
 def _build_url(page, _anchor=None, **params):

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -21,7 +21,6 @@ if version[-5:] == ".dev0":  # To pass tests on commits during development
     version = version[:-1] + str(int(version[-1]) - 1)
 
 app = flask.Flask(__name__, template_folder="templates", static_folder="static")
-app.jinja_env.policies["ext.i18n.trimmed"] = True
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
 config.configure_app(app)

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -224,10 +224,8 @@ def _link(page, name=None, _anchor=None, _class=None, **params):
 @app.context_processor
 def linker():
     path = flask.request.path
-    if path[-11:] == "/index":
-        path = path[:-11]
-    if path[-5:] == ".html":
-        path = path[:-5]
+    if path[-6:] == "/index":
+        path = path[:-6]
     if path[-1:] == "/":
         path = path[:-1]
 
@@ -303,7 +301,13 @@ def display_card():
         return name
 
     def card_name_from_page(name):
-        page_name = HELPER.get(name, {}).get("self").name
+        # Strange case where double-faced cards make the page reload
+        # with `name` shorten by 5.
+        page_name = (
+            HELPER.get([key for key in HELPER if key.startswith(name)][0], {})
+            .get("self")
+            .name
+        )
         if "❌" in page_name:
             page_name = page_name[2:]
         return page_name

--- a/barrins_codex/__init__.py
+++ b/barrins_codex/__init__.py
@@ -187,14 +187,15 @@ def commanders():
 def index(page=None):
     redirect = False
     if not page:
-        page = "index.html"
+        page = "index"
         redirect = True
+
     page = "/" + page
     if redirect:
         return flask.redirect(page, 301)
 
     context = copy.copy(BASE_CONTEXT)
-    return flask.render_template(page, **context)
+    return flask.render_template(page + ".html", **context)
 
 
 def _build_url(page, _anchor=None, **params):
@@ -222,7 +223,7 @@ def _link(page, name=None, _anchor=None, _class=None, **params):
 @app.context_processor
 def linker():
     path = flask.request.path
-    if path[-11:] == "/index.html":
+    if path[-11:] == "/index":
         path = path[:-11]
     if path[-5:] == ".html":
         path = path[:-5]

--- a/barrins_codex/navigation.py
+++ b/barrins_codex/navigation.py
@@ -23,9 +23,9 @@ class Nav:
         else:
             res = path + "/" + res
         if not self.children:
-            url = res + ".html"
+            url = res
         elif self.index:
-            url = res + "/index.html"
+            url = res + "/index"
         else:
             url = None
         return Page(self.name, res, url, self.cat, self.crop)

--- a/barrins_codex/templates/decks/_layout_decks.html
+++ b/barrins_codex/templates/decks/_layout_decks.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 
-{% set page = request.path[:-5] %}
+{% set page = request.path %}
 {% set carte = deck_name(page) %}
 {% set og_image = self.banner_img() %}
 

--- a/barrins_codex/templates/decks/_layout_decks.html
+++ b/barrins_codex/templates/decks/_layout_decks.html
@@ -1,7 +1,6 @@
 {% extends "layout.html" %}
 
-{% set page = request.path %}
-{% set carte = deck_name(page) %}
+{% set carte = deck_name(request.path) %}
 {% set og_image = self.banner_img() %}
 
 {% block banner %}

--- a/barrins_codex/templates/matchs/_layout_matchs.html
+++ b/barrins_codex/templates/matchs/_layout_matchs.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 
-{% set page = request.path[:-5] %}
+{% set page = request.path %}
 {% set match = match_name(page) %}
 {% set image = "img/"+page[1:]+".jpg" %}
 {% set og_image = url_for('static', filename=image) %}


### PR DESCRIPTION
- URL : Suppression du ".html" en fin d'adresse
- URL : Utilisation des liens en ".html" sans rejet 404
- URL : N'affiche plus "index" par défaut sur l'accueil